### PR TITLE
Determine callback and options arguments first

### DIFF
--- a/src/cta.js
+++ b/src/cta.js
@@ -86,6 +86,12 @@
 	};
 
 	function cta(trigger, target, options, callback) {
+		// Support optional arguments
+		if (typeof options === 'function') {
+			callback = options;
+			options = {};
+		}
+
 		if (!isSupportedBrowser) {
 			if (callback) {
 				callback(target);
@@ -100,11 +106,6 @@
 			dummy,
 			extraTransitionDuration = 1;
 
-		// Support optional arguments
-		if (typeof options === 'function') {
-			callback = options;
-			options = {};
-		}
 		options = options || {};
 		options.duration = options.duration || defaults.duration;
 		options.targetShowDuration = options.targetShowDuration || getAnimationTime(target) || defaults.targetShowDuration;


### PR DESCRIPTION
If not done first thing, the library will throw an error in unsupported browsers if `options` object had been provided.