### PR TITLE
Make extraTransitionDuration available through the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Animate an element `sourceElement` onto `targetElement`.
 * `options` - A map of additional options to control the animation behaviour.
 	* `duration` - Duration (in seconds) of animation. Default is `0.3` seconds.
 	* `targetShowDuration` - Duration (in seconds) of `targetElement` to become visible, if hidden initially. The library will automatically try to figure this out from the element's computed styles. Default is `0` seconds.
+	* `extraTransitionDuration` - Extra duration (in seconds) of `targetElement` to provide visual continuity between the animation and the rendering of the `targetElement`. Default is `1` second.
 	* `relativeToWindow` - Set to true if your target element is fixed positioned in the window. Default is relative to document (works good with normal elements).
 * `callback` - Optional callback to execute after animation completes.
 

--- a/src/cta.js
+++ b/src/cta.js
@@ -97,8 +97,7 @@
 			triggerBackground,
 			targetBounds,
 			triggerBounds,
-			dummy,
-			extraTransitionDuration = 1;
+			dummy;
 
 		// Support optional arguments
 		if (typeof options === 'function') {
@@ -109,6 +108,7 @@
 		options.duration = options.duration || defaults.duration;
 		options.targetShowDuration = options.targetShowDuration || getAnimationTime(target) || defaults.targetShowDuration;
 		options.relativeToWindow = options.relativeToWindow || defaults.relativeToWindow;
+		options.extraTransitionDuration = options.extraTransitionDuration || defaults.extraTransitionDuration;
 
 		// Set some properties to make the target visible so we can get its dimensions.
 		// Set `display` to `block` only when its already hidden. Otherwise changing an already visible
@@ -168,11 +168,11 @@
 				callback(target);
 			}
 			// Animate the dummy element to zero opacity while the target is getting rendered.
-			dummy.style.transitionDuration = (options.targetShowDuration + extraTransitionDuration) + 's';
+			dummy.style.transitionDuration = (options.targetShowDuration + options.extraTransitionDuration) + 's';
 			dummy.style.opacity = 0;
 			setTimeout(function () {
 				dummy.parentNode.removeChild(dummy);
-			}, (options.targetShowDuration + extraTransitionDuration) * 1000);
+			}, (options.targetShowDuration + options.extraTransitionDuration) * 1000);
 		});
 
 		// Return a reverse animation function for the called animation.


### PR DESCRIPTION
Currently the user cannot change the `extraTransitionDuration` through the `options` arguments.
This fix uses the value from the `defaults` or from the `options` (if provided) object so that it can be set in the `options` when calling the `cta` function.