### PR TITLE
Replaces deprecated licenses field with new license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,7 @@
   "bugs": {
     "url": "https://github.com/chinchang/cta.js/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/chinchang/cta.js/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "animation",
     "transition",


### PR DESCRIPTION
This fixes the warning thrown when doing npm install

``` bash
npm WARN cta@0.3.2 No license field.
```

Refer to https://docs.npmjs.com/files/package.json#license
