### PR TITLE
Add support for jit-grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,13 +42,11 @@ module.exports = function(grunt) {
 	});
 
 	// Dependencies
-	grunt.loadNpmTasks('grunt-contrib-jshint');
-	grunt.loadNpmTasks('grunt-contrib-uglify');
-	grunt.loadNpmTasks('grunt-contrib-concat');
+	require('jit-grunt')(grunt);
 
 	grunt.registerTask('build',[
 		'jshint',
-		'uglify', 
+		'uglify',
 		'concat'
 	]);
 	grunt.registerTask('default','build');

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "library"
   ],
   "devDependencies": {
-    "grunt-contrib-concat": "~0.5.1",
     "grunt": "~0.4.5",
+    "grunt-contrib-concat": "~0.5.1",
     "grunt-contrib-jshint": "^0.11.0",
-    "grunt-contrib-uglify": "~0.8.0"
+    "grunt-contrib-uglify": "~0.8.0",
+    "jit-grunt": "^0.9.1"
   }
 }


### PR DESCRIPTION
Just In Time plugin loader for Grunt - https://www.npmjs.com/package/jit-grunt

Improves build time of Grunt tasks by loading plugins as and when they are needed rather than loading them all upfront before executing